### PR TITLE
Add a REDIS_NAMESPACE environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby
 
-RUN gem install rack sidekiq
+RUN gem install rack sidekiq redis-namespace
 COPY config.ru config.ru
 
 EXPOSE 9292

--- a/config.ru
+++ b/config.ru
@@ -18,4 +18,5 @@ end
 
 require 'set'
 require 'sidekiq/web'
-run Sidekiq::Web
+# run Sidekiq::Web
+run Rack::URLMap.new(ENV.fetch('SIDEKIQ_PATH', '/sidekiq') => Sidekiq::Web)

--- a/config.ru
+++ b/config.ru
@@ -3,11 +3,15 @@ require 'sidekiq'
 Sidekiq.configure_client do |config|
   config.redis =
     if ENV['REDIS_SENTINEL_SERVICE'].nil?
-      { url: (ENV['REDIS_URL'] || 'redis://redis') }
+      { 
+        url: (ENV['REDIS_URL'] || 'redis://redis'), 
+        namespace: ENV['REDIS_NAMESPACE'] 
+      }
     else
       {
         url: (ENV['REDIS_URL'] || 'redis://mymaster'),
-        sentinels: [{ host: ENV['REDIS_SENTINEL_SERVICE'], port: '26379' }]
+        sentinels: [{ host: ENV['REDIS_SENTINEL_SERVICE'], port: '26379' }],
+        namespace: ENV['REDIS_NAMESPACE']
       }
     end
 end


### PR DESCRIPTION
While it's typically a bad idea to use Redis namespaces, this is life, folks, and people make bad decisions.